### PR TITLE
Improving reproducibility using Docker (PERMBU_MINT)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM continuumio/miniconda3:4.7.12
+
+RUN apt-get --allow-releaseinfo-change update && \
+    apt-get install -y build-essential
+
+ADD ./environment.yml ./environment.yml
+
+RUN conda install -n base -c conda-forge mamba && \
+    mamba env update -n base -f ./environment.yml && \
+    conda clean -afy
+
+RUN R -e 'install.packages(c("here", "SGL", "matrixcalc", "igraph", "sn", "scoringRules", "fBasics", "msm", "gtools", "lubridate", "forecast", "abind", "glmnet", "SuppDists"), repos="http://cran.us.r-project.org")'
+
+RUN R -e 'install.packages("hts", repos="http://cran.us.r-project.org")'
+
+RUN R -e 'install.packages(c("gsl", "copula", "propagate", "plotrix"), repos="http://cran.us.r-project.org")'
+
+COPY . .
+RUN pip install -e .

--- a/Makefile.experiment
+++ b/Makefile.experiment
@@ -1,0 +1,19 @@
+IMAGE := gluontshier
+ROOT := $(shell dirname $(realpath $(firstword ${MAKEFILE_LIST})))
+
+DOCKER_PARAMETERS := \
+	--user $(shell id -u) \
+	-v ${ROOT}:/app \
+	-w /app \
+	-e HOME=/tmp
+
+init:
+	docker build -t ${IMAGE} .
+
+run_module: .require-module
+	docker run -i --rm ${DOCKER_PARAMETERS} ${IMAGE} ${module}
+
+.require-module:
+ifndef module
+	$(error module is required)
+endif

--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ If results are available for fewer number of runs, then mean/std is calculated o
 To reproduce results easier we recommend using Docker:
 
 1. Initialize the Docker image using: `make init -f Makefile.experiment`.
-2. Run each instruction using: `make run_module module="python experiments/run_experiment_with_best_hps.py --dataset dataset --method method" -f Makefile.experiment`
+2. Run each instruction using: 
+
+```
+make run_module module="python experiments/run_experiment_with_best_hps.py --dataset dataset --method method" -f Makefile.experiment
+```
+
 3. To run all `PERMBU_MINT` experiments use:
 
 ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ python experiments/show_results.py --dataset dataset --method method --num-runs 
 ```
 If results are available for fewer number of runs, then mean/std is calculated over only those results available in `experiments/results` folder.
 
+### Reproducing results using Docker
+
+To reproduce results easier we recommend using Docker:
+
+1. Initialize the Docker image using: `make init -f Makefile.experiment`.
+2. Run each instruction using: `make run_module module="python experiments/run_experiment_with_best_hps.py --dataset dataset --method method" -f Makefile.experiment`
+3. To run all `PERMBU_MINT` experiments use:
+
+```
+for dataset in labour traffic tourism tourism large; 
+	do make run_module module="python experiments/run_experiment_with_best_hps.py --dataset $dataset --method PERMBU_MINT" -f Makefile.experiment;
+done
+```
+
 ## Citing
 
 If the datasets, benchmark, or methods are useful for your research, you can cite the following paper:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,16 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - pip
+  - numpy
+  - pandas
+  - matplotlib
+  - scikit-learn
+  - statsmodels
+  - r-base
+  - pip:
+    - mxnet
+    - rpy2==2.9
+    - jinja2


### PR DESCRIPTION
Hi,

I had some issues trying to replicate the code, especially the `PERMBU_MINT` model. I wrote a `Dockerfile` to solve those issues. Now, replicating the results is as easy as running:

1. `make init -f Makefile.experiment`.
2. 
```
make run_module module="python experiments/run_experiment_with_best_hps.py --dataset traffic --method PERMBU_MINT" -f Makefile.experiment
```

In the `README.md` the user can find the instructions to use this approach.

The Docker image includes all python dependencies among the R ones.